### PR TITLE
Ability to add a key into the order map

### DIFF
--- a/body.go
+++ b/body.go
@@ -46,6 +46,10 @@ func (obj *OrderMap) Del(key string) {
 func (obj *OrderMap) Keys() []string {
 	return obj.keys
 }
+func (obj *OrderMap) AddKey(key string) {
+	obj.Del(key)
+	obj.keys = append(obj.keys, key)
+}
 func (obj *OrderMap) parseHeaders() (map[string][]string, []string) {
 	head := make(http.Header)
 	for _, kk := range obj.keys {


### PR DESCRIPTION
Really simple fix to be able to add just a key into a order map, for dynamically computed headers such as 'Host' and still retain their order.