### PR TITLE
removed "referer" header setting

### DIFF
--- a/client.go
+++ b/client.go
@@ -149,7 +149,6 @@ func (obj *Client) do(req *http.Request, option *RequestOption) (resp *http.Resp
 		}
 		ireq.Response = resp
 		ireq.Header = defaultHeaders()
-		ireq.Header.Set("Referer", req.URL.String())
 		for key := range ireq.Header {
 			if val := req.Header.Get(key); val != "" {
 				ireq.Header.Set(key, val)

--- a/requests.go
+++ b/requests.go
@@ -3,7 +3,6 @@ package requests
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -286,14 +285,6 @@ func (obj *Client) request(ctx context.Context, option *RequestOption) (response
 		return response, tools.WrapError(errFatal, errors.New("tempRequest 构造request失败"), err)
 	}
 	reqs.Header = headers
-	//add Referer
-	if reqs.Header.Get("Referer") == "" {
-		if option.Referer != "" {
-			reqs.Header.Set("Referer", option.Referer)
-		} else {
-			reqs.Header.Set("Referer", fmt.Sprintf("%s://%s", reqs.URL.Scheme, reqs.URL.Host))
-		}
-	}
 
 	//set ContentType
 	if option.ContentType != "" && reqs.Header.Get("Content-Type") == "" {


### PR DESCRIPTION
As already mentioned in issue#24 it is uncommon for the client to set a default "Referer" header.
It does not make sense from my point of view. A browser has usually a very different behaviour setting the "Referer" header than in this implementation. Therefore I find it useful to remove the default setting of the "Referer" header.